### PR TITLE
Implement CreateUser from app-gateway-svc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/hwsc-org/hwsc-app-gateway-svc
 
 require (
 	cloud.google.com/go v0.36.0 // indirect
+	github.com/Pallinder/go-randomdata v1.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang-migrate/migrate/v4 v4.2.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/Pallinder/go-randomdata v1.1.0 h1:gUubB1IEUliFmzjqjhf+bgkg1o6uoFIkRsP3VrhEcx8=
+github.com/Pallinder/go-randomdata v1.1.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/service/client_user.go
+++ b/service/client_user.go
@@ -111,6 +111,21 @@ func (svc *userService) getStatus() (*pbuser.UserResponse, error) {
 	return resp, nil
 }
 
+// createUser creates a user
+// On success, returns user object with password set to empty for security reasons.
+func (svc *userService) createUser(user *lib.User) (*pbuser.UserResponse, error) {
+	if err := refreshConnection(svc, consts.UserClientTag); err != nil {
+		return nil, err
+	}
+	// not guaranteed that we are connected, but return the error and try reconnecting again later
+	resp, err := svc.client.CreateUser(context.TODO(), &pbuser.UserRequest{User: user})
+	if err != nil {
+		log.Error(consts.UserClientTag, err.Error())
+		return nil, err
+	}
+	return resp, nil
+}
+
 // makeNewAuthSecret forces user-svc to replace its current AuthSecret.
 // Returns an error from the user-svc.
 func (svc *userService) makeNewAuthSecret() error {

--- a/service/client_user_test.go
+++ b/service/client_user_test.go
@@ -86,7 +86,7 @@ func Test_userCreateUser(t *testing.T) {
 		} else {
 			assert.Nil(t, err, c.desc)
 			assert.NotNil(t, resp.GetUser().GetUuid(), c.desc)
-			assert.Equal(t, auth.PermissionStringMap[auth.NoPermission], resp.GetUser().GetPermissionLevel())
+			assert.Equal(t, auth.PermissionStringMap[auth.NoPermission], resp.GetUser().GetPermissionLevel(), c.desc)
 		}
 	}
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -62,6 +62,14 @@ func TestMain(m *testing.M) {
 	// run all migration up to the most active
 	if err := migration.Up(); err != nil {
 		logger.Error(consts.TestTag, "Failed to load active migration files:", err.Error())
+		// hack to reset DB to default settings with no entries
+		logger.Info(consts.TestTag, "Resetting migration")
+		if downErr := migration.Down(); downErr != nil {
+			logger.Fatal(consts.TestTag, "Failed to migrate down", err.Error())
+		}
+		if upErr := migration.Up(); upErr != nil {
+			logger.Fatal(consts.TestTag, "Failed to load active migration files:", err.Error())
+		}
 	}
 
 	// start the tests


### PR DESCRIPTION
Closes https://github.com/hwsc-org/hwsc-app-gateway-svc/issues/32
Add a new package for generating random data: https://github.com/Pallinder/go-randomdata
User validation is still done in user-svc.
Integration test is todo in task hwsc-org/hwsc-api-blocks#105