### PR TITLE
Implement get new auth token

### DIFF
--- a/service/client_user.go
+++ b/service/client_user.go
@@ -270,7 +270,29 @@ func (svc *userService) replaceCurrAuthSecret() error {
 
 // getNewAuthToken generates and retrieves a new auth token for the use
 // Returns a new auth token string
-func (svc *userService) getNewAuthToken(token string) (*pbuser.UserResponse, error) {
-	// TODO
-	return nil, nil
+func (svc *userService) getNewAuthToken(token string) (string, error) {
+	if err := refreshConnection(svc, consts.UserClientTag); err != nil {
+		return "", err
+	}
+	// not guaranteed that we are connected, but return the error and try reconnecting again later
+	resp, err := svc.client.GetNewAuthToken(
+		context.TODO(),
+		&pbuser.UserRequest{
+			Identification: &lib.Identification{
+				Token: token,
+			},
+		},
+	)
+	if err != nil {
+		log.Error(consts.UserClientTag, err.Error())
+		return "", err
+	}
+	id := resp.GetIdentification()
+	newSecret := id.GetSecret()
+	if err := auth.ValidateSecret(newSecret); err != nil {
+		log.Error(consts.UserClientTag, err.Error())
+		return "", err
+	}
+	currAuthSecret = newSecret
+	return id.GetToken(), nil
 }

--- a/service/client_user.go
+++ b/service/client_user.go
@@ -267,3 +267,10 @@ func (svc *userService) replaceCurrAuthSecret() error {
 	currAuthSecret = newAuthSecret
 	return nil
 }
+
+// getNewAuthToken generates and retrieves a new auth token for the use
+// Returns a new auth token string
+func (svc *userService) getNewAuthToken(token string) (*pbuser.UserResponse, error) {
+	// TODO
+	return nil, nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -136,8 +136,8 @@ func (s *Service) UpdateUser(ctx context.Context, req *pbsvc.AppGatewayServiceRe
 	}, nil
 }
 
-// GetNewAuthToken looks through users and perform email and password match
-// Returns a token string
+// GetNewAuthToken generates and retrieves a new auth token for the use
+// Returns a new auth token string
 func (s *Service) GetNewAuthToken(ctx context.Context, req *pbsvc.AppGatewayServiceRequest) (*pbsvc.AppGatewayServiceResponse, error) {
 	// TODO
 	return &pbsvc.AppGatewayServiceResponse{

--- a/service/service.go
+++ b/service/service.go
@@ -136,13 +136,31 @@ func (s *Service) UpdateUser(ctx context.Context, req *pbsvc.AppGatewayServiceRe
 	}, nil
 }
 
-// GetNewAuthToken generates and retrieves a new auth token for the use
+// GetNewAuthToken generates and retrieves a new auth token for the user
 // Returns a new auth token string
 func (s *Service) GetNewAuthToken(ctx context.Context, req *pbsvc.AppGatewayServiceRequest) (*pbsvc.AppGatewayServiceResponse, error) {
-	// TODO
+	log.RequestService("GetNewAuthToken")
+
+	if ok := isStateAvailable(); !ok {
+		log.Info(consts.AppGatewayServiceTag, consts.ErrServiceUnavailable.Error())
+		return nil, status.Error(codes.Unavailable, consts.ErrServiceUnavailable.Error())
+	}
+
+	if req == nil || req.GetUserRequest() == nil || req.GetUserRequest().GetIdentification() == nil ||
+		req.GetUserRequest().GetIdentification().GetToken() == "" {
+		log.Error(consts.AppGatewayServiceTag, consts.ErrNilRequest.Error())
+		return nil, status.Error(codes.InvalidArgument, consts.ErrNilRequest.Error())
+	}
+	authToken, err := userSvc.getNewAuthToken(req.GetUserRequest().GetIdentification().GetToken())
+	if err != nil {
+		log.Error(consts.AppGatewayServiceTag, err.Error())
+		return nil, err
+	}
+
 	return &pbsvc.AppGatewayServiceResponse{
 		Status:  &pbsvc.AppGatewayServiceResponse_Code{Code: uint32(codes.OK)},
 		Message: codes.OK.String(),
+		Token:   authToken,
 	}, nil
 }
 


### PR DESCRIPTION
A new auth token can be generated from existing auth token that are valid not expired.

References:
- [Spec](https://hwsc-org.github.io/wikis/app-gateway-svc/specifications.html#getnewauthtoken)
- closes https://github.com/hwsc-org/hwsc-user-svc/issues/114